### PR TITLE
Add bug report information retrieval for package.json.

### DIFF
--- a/wasp
+++ b/wasp
@@ -97,6 +97,17 @@ class Details:
             if 'keywords' in self.details:
                 package['keywords'] = self.details['keywords']
 
+            bugs = {}
+            if 'issue_tracker_url' in self.details and len(self.details['issue_tracker_url']) > 0:
+                bugs['url'] = self.details['issue_tracker_url']
+
+            if 'bug_report_email' in self.details and len(self.details['bug_report_email']) > 0:
+                bugs['email'] = self.details['bug_report_email']
+
+            if len(bugs) > 0:
+                package['bugs'] = bugs
+
+
             with open('package.json', 'w') as fp:
                 json.dump(package, fp, sort_keys=True, indent=4, separators=(',', ': '))
 
@@ -106,6 +117,8 @@ class Details:
             self.name()
             self.description()
             self.keywords()
+            self.issue_tracker_url()
+            self.bug_report_email()
         if args.manifest:
             self.short_name()
             self.app_colors('theme_color')
@@ -148,6 +161,16 @@ class Details:
             self.app_colors(color_type)
         else:
             self.details[color_type] = '#' + self.details[color_type].upper()
+
+    def issue_tracker_url(self):
+        """ Prompt user for URL to the issue tracker of the project. """
+        self.details['issue_tracker_url'] = input(
+            "Issue Tracker URL " + str(on(["P"], args)) + " (" + Colors.OKBLUE + "\"\"" + Colors.ENDC + "): ")
+
+    def bug_report_email(self):
+        """ Prompt user for the email address to which the bug reports can be sent. """
+        self.details['bug_report_email'] = input(
+            "Bug Report Email " + str(on(["P"], args)) + " (" + Colors.OKBLUE + "\"\"" + Colors.ENDC + "): ")
 
     def start_url(self):
         """ Prompt user for URL that loads when application launched. Default is /. """


### PR DESCRIPTION
Solves #32 . A simple and straightforward implementation, based on the documentation you provided in the description of the issue. Basically both URL and email info are asked during the "wasp init -p" stage, and they both default to empty string. Only the ones that are not an empty string are featured on package.json. If neither information is entered, no bug reporting info is added to package.json.